### PR TITLE
Allow to override the user check

### DIFF
--- a/signal-cli
+++ b/signal-cli
@@ -3,7 +3,7 @@ if [ "$(whoami)" = "root" ]; then
     echo "This command will run under the signal-cli user (@SCUSER@)."
     su -l @SCUSER@ -c "$0 $*"
     exit $?
-elif [ "$(whoami)" != "@SCUSER@" ]; then
+elif [ "$(whoami)" != "@SCUSER@" -a "${SIGNAL_USER_OVERRIDE}" != "1" ]; then
     echo "This command must be run under the signal-cli user (@SCUSER@)."
     exit 1
 fi

--- a/signal-cli.spec
+++ b/signal-cli.spec
@@ -35,7 +35,7 @@
 %define version_java_major_latest_next %(echo $[ %{version_java_major} + 1])
 %endif
 
-%global release_token 2
+%global release_token 3
 
 
 %global basedir		%{_libdir}/%{pname}
@@ -296,6 +296,9 @@ systemctl condrestart %{pname}.service
 
 
 %changelog
+* Wed Mar 25 2026 Frank Wall <fw@moov.de> - 0.14.1-3
+- Wrapper script: allow to override the user check
+
 * Wed Mar 25 2026 Peter Bieringer <pb@bieringer.de> - 0.14.1-2
 - Spec: specify epoch for java-latest
 - Spec: fix implanting of libsignal_jni_amd64.so on EL8


### PR DESCRIPTION
Currently the wrapper script checks if it is running as the designated signal-cli user and aborts, when called as any other user.

However, I am running signal-cli as a different user, which works perfectly fine. There are several use-cases where signal-user must be run as a different user for better interoperability with other apps or system services.

This PR allows to override the user check by setting the `SIGNAL_USER_OVERRIDE=1` environment variable.